### PR TITLE
Rely on reset-css package

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "presets": [ "stage-3", "env" ],
   "plugins": [
+    "preval",
     "transform-es2015-modules-commonjs"
   ],
   "comments": false

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,4 +1,7 @@
 {
   "root": true,
-  "extends": "eslint-config-jane"
+  "extends": "eslint-config-jane",
+  "globals": {
+    "preval": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -31,9 +31,13 @@
     "reset.css",
     "styled-components"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "reset-css": "^3.0.0"
+  },
   "devDependencies": {
+    "babel-cli": "6.26.0",
     "babel-eslint": "8.2.2",
+    "babel-plugin-preval": "1.6.4",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
     "babel-preset-env": "1.6.1",
     "babel-preset-stage-3": "6.24.1",

--- a/src/index.js
+++ b/src/index.js
@@ -1,48 +1,10 @@
 import { css } from 'styled-components'
 
 export const reset = css`
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-}
-article, aside, details, figcaption, figure,
-footer, header, hgroup, menu, nav, section {
-  display: block;
-}
-body {
-  line-height: 1;
-}
-ol, ul {
-  list-style: none;
-}
-blockquote, q {
-  quotes: none;
-}
-blockquote:before, blockquote:after,
-q:before, q:after {
-  content: '';
-  content: none;
-}
-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-}
+  ${preval`
+    const fs = require('fs')
+    module.exports = fs.readFileSync(require.resolve('reset-css'), 'utf8')
+  `};
 `
 
 export default reset


### PR DESCRIPTION
I think it would be a good idea to just use the [reset-css](https://www.npmjs.com/package/reset-css) package directly instead of having a separate reset.

There might be different ways to do this instead of using preval, but I thought this was a pretty nice solution overall. 