### PR TITLE
include typescript declaration file in package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "main": "lib/index.js",
   "files": [
-    "lib/index.js"
+    "lib/index.js",
+    "index.d.ts"
   ],
   "scripts": {
     "build": "babel src/ -d lib/",


### PR DESCRIPTION
Right now, installing this package doesn't have the `index.d.ts` file included inside it:

```
.
├── LICENSE.md
├── README.md
├── lib
│   └── index.js
└── package.json
```

This change will make sure that the declaration file is published with the rest of the package.