### PR TITLE
Improve tree-shake-ability for bundlers like rollup/vite/etc

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "license": "LGPL-3.0",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],

--- a/package.json
+++ b/package.json
@@ -13,12 +13,13 @@
   },
   "license": "LGPL-3.0",
   "main": "lib/index.js",
+  "module": "lib/esm/index.js",
   "types": "lib/index.d.ts",
   "files": [
     "lib"
   ],
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && tsc -p tsconfig.esm.json",
     "format": "prettier --write *.js \"src/*.ts\"",
     "prebuild": "run-s -s test clean",
     "clean": "rm -rf lib && mkdir -p lib",

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": false,
+    "outDir": "./lib/esm/",
+    "module": "ES2020"
+  }
+}


### PR DESCRIPTION
# Change Type

* [ ] Feature
* [x] Chore
* [ ] Bug Fix

# Change Level

* [ ] major
* [ ] minor
* [x] patch

# Further Information (screenshots, bug report links, etc.)

This PR adds a `module` entry that all popular bundlers use for tree-shaking and removing unused imports. This makes it easier to bundle `styled-reset` with rollup/vite/snowpack/etc.

Also added the missing `types` field that TypeScript uses to resolve type definitions for a given npm package.

# Checklist

* [x] Added tests / did not decrease code coverage
* [x] Tested in supported environments (common browsers or current and LTS Node)